### PR TITLE
Report undefined symbols as errors

### DIFF
--- a/src/lalr/Grammar.cpp
+++ b/src/lalr/Grammar.cpp
@@ -245,7 +245,9 @@ Grammar& Grammar::literal( const char* literal, int line )
         }        
         if ( active_precedence_directive_ )
         {
-            active_production_->set_precedence_symbol( literal_symbol(literal, line) );
+            GrammarSymbol* symbol = literal_symbol( literal, line );
+            active_production_->set_precedence_symbol( symbol );
+            symbol->set_referenced_in_precedence_directive( true );
             active_precedence_directive_ = false;
         }
         else
@@ -279,7 +281,9 @@ Grammar& Grammar::regex( const char* regex, int line )
         }
         if ( active_precedence_directive_ )
         {
-            active_production_->set_precedence_symbol( regex_symbol(regex, line) );
+            GrammarSymbol* symbol = regex_symbol( regex, line );
+            symbol->set_referenced_in_precedence_directive( true );
+            active_production_->set_precedence_symbol( symbol );
             active_precedence_directive_ = false;
         }
         else
@@ -309,7 +313,9 @@ Grammar& Grammar::identifier( const char* identifier, int line )
         }
         if ( active_precedence_directive_ )
         {
-            active_production_->set_precedence_symbol( non_terminal_symbol(identifier, line) );
+            GrammarSymbol* symbol = non_terminal_symbol( identifier, line );
+            symbol->set_referenced_in_precedence_directive( true );
+            active_production_->set_precedence_symbol( symbol );
             active_precedence_directive_ = false;
         }
         else

--- a/src/lalr/GrammarCompiler.hpp
+++ b/src/lalr/GrammarCompiler.hpp
@@ -43,11 +43,7 @@ private:
     void set_symbols( std::unique_ptr<ParserSymbol[]>& symbols, int symbols_size );
     void set_transitions( std::unique_ptr<ParserTransition[]>& transitions, int transitions_size );
     void set_states( std::unique_ptr<ParserState[]>& states, int states_size, const ParserState* start_state );
-    void set_lexer_allocations( std::unique_ptr<RegexCompiler>& lexer_allocations );
-    void set_whitespace_lexer_allocations( std::unique_ptr<RegexCompiler>& whitespace_lexer_allocations );
     void populate_parser_state_machine( const Grammar& grammar, const GrammarGenerator& generator );
-    void populate_lexer_state_machine( const GrammarGenerator& generator, ErrorPolicy* error_policy );
-    void populate_whitespace_lexer_state_machine( const Grammar& grammar, ErrorPolicy* error_policy );
 };
 
 }

--- a/src/lalr/GrammarGenerator.cpp
+++ b/src/lalr/GrammarGenerator.cpp
@@ -442,8 +442,8 @@ void GrammarGenerator::calculate_identifiers()
 //
 // Any symbols with one or more productions are assumed to be non-terminals
 // and any symbols with no productions are assumed to be terminals.  Another
-// pass is made over the symbols in to convert non-terminals symbols that 
-// contain only a single production with one terminal symbol into terminals.
+// pass is made over the symbols to convert non-terminals symbols with only
+// a single production with one terminal symbol into terminals.
 // See `Grammar::calculate_implicit_terminal_symbols()`.
 //
 // The `.start`, `.end`, and `.error` symbols are exempt from the above 
@@ -462,21 +462,21 @@ void GrammarGenerator::calculate_terminal_and_non_terminal_symbols()
 }
 
 /**
-// Calculate the non terminal symbols that are really just named terminals.
+// Calculate the non-terminal symbols that are really named terminals.
 //
 // Any symbols that contain a single production that contains only a terminal 
-// symbol are really just acting as names for that terminal symbol.  To make 
-// the parser easier to understand and more efficient these symbols are 
-// collapsed by making any references to the non terminal symbol refer directly
-// to the terminal symbol.  The identifier of the terminal is changed to be 
-// the more readable name of the non terminal.
+// symbol are aliases for that terminal symbol.  To make the parser easier to
+// understand and more efficient these symbols are  collapsed by making any
+// references to the non-terminal refer directly to the terminal.  The
+// identifier of the terminal is changed to be the more readable name of the
+// non-terminal.
 //
-// For example the rule 'integer: "[0-9]+";' creates a non terminal
-// symbol 'integer' and a terminal symbol '"[0-9]+"'.  The non terminal
+// For example the rule 'integer: "[0-9]+";' creates a non-terminal
+// symbol 'integer' and a terminal symbol '"[0-9]+"'.  The non-terminal
 // symbol 'integer' is redundant from the point of view of the parser as it
 // adds only a trivial reduction from one symbol type to another.  To optimize
-// this situation the terminal is collapsed into the non terminal keeping the
-// more readable name of the non terminal but removing the redundant 
+// this situation the terminal is collapsed into the non-terminal keeping the
+// more readable name of the non-terminal but removing the redundant 
 // reduction.
 */
 void GrammarGenerator::calculate_implicit_terminal_symbols()

--- a/src/lalr/GrammarGenerator.cpp
+++ b/src/lalr/GrammarGenerator.cpp
@@ -357,9 +357,9 @@ void GrammarGenerator::check_for_undefined_symbol_errors()
         {
             const GrammarSymbol* symbol = i->get();
             LALR_ASSERT( symbol );
-            if ( symbol->symbol_type() == SYMBOL_NON_TERMINAL && symbol->productions().empty() && symbol->precedence() <= 0 )
+            if ( symbol->symbol_type() == SYMBOL_NON_TERMINAL && symbol->productions().empty() && !symbol->referenced_in_precedence_directive() )
             {
-                error( 1, PARSER_ERROR_UNDEFINED_SYMBOL, "undefined symbol '%s' in grammar '%s'", symbol->identifier().c_str(), identifier_.c_str() );
+                error( symbol->line(), PARSER_ERROR_UNDEFINED_SYMBOL, "undefined symbol '%s'", symbol->identifier().c_str(), identifier_.c_str() );
             }
         }
     }

--- a/src/lalr/GrammarSymbol.cpp
+++ b/src/lalr/GrammarSymbol.cpp
@@ -23,6 +23,7 @@ GrammarSymbol::GrammarSymbol( const std::string& lexeme )
 , line_( 0 )
 , index_( -1 )
 , nullable_( false )
+, referenced_in_precedence_directive_( false )
 , first_()
 , follow_()
 , productions_()
@@ -72,6 +73,11 @@ int GrammarSymbol::index() const
 bool GrammarSymbol::nullable() const
 {
     return nullable_;
+}
+
+bool GrammarSymbol::referenced_in_precedence_directive() const
+{
+    return referenced_in_precedence_directive_;
 }
 
 const std::set<const GrammarSymbol*, GrammarSymbolLess>& GrammarSymbol::first() const
@@ -178,6 +184,11 @@ void GrammarSymbol::set_index( int index )
 void GrammarSymbol::set_nullable( bool nullable )
 {
     nullable_ = nullable;
+}
+
+void GrammarSymbol::set_referenced_in_precedence_directive( bool referenced_in_precedence_directive )
+{
+    referenced_in_precedence_directive_ = referenced_in_precedence_directive;
 }
 
 void GrammarSymbol::append_production( GrammarProduction* production )

--- a/src/lalr/GrammarSymbol.hpp
+++ b/src/lalr/GrammarSymbol.hpp
@@ -25,6 +25,7 @@ class GrammarSymbol
     int line_; ///< The line that this symbol is defined on.
     int index_; ///< The index of this symbol among all symbols.
     bool nullable_; ///< True if this symbol is nullable otherwise false.
+    bool referenced_in_precedence_directive_; ///< True if this symbol is referenced by a %precedence directive.
     std::set<const GrammarSymbol*, GrammarSymbolLess> first_; ///< The symbols that can start this symbol in a production or regular expression.
     std::set<const GrammarSymbol*, GrammarSymbolLess> follow_; ///< The symbols that can follow this symbol in a production or regular expression.
     std::vector<GrammarProduction*> productions_; ///< The productions that reduce to this symbol.
@@ -41,6 +42,7 @@ public:
     int line() const;
     int index() const;
     bool nullable() const;
+    bool referenced_in_precedence_directive() const;
     const std::set<const GrammarSymbol*, GrammarSymbolLess>& first() const;
     const std::set<const GrammarSymbol*, GrammarSymbolLess>& follow() const;
     const std::vector<GrammarProduction*>& productions() const;
@@ -56,6 +58,7 @@ public:
     void set_line( int line );
     void set_index( int index );
     void set_nullable( bool nullable );
+    void set_referenced_in_precedence_directive( bool referenced_in_precedence_directive );
     void append_production( GrammarProduction* production );
     void calculate_identifier();
     void replace_by_non_terminal( const GrammarSymbol* non_terminal_symbol );    

--- a/src/lalr/RegexCompiler.cpp
+++ b/src/lalr/RegexCompiler.cpp
@@ -23,8 +23,6 @@ RegexCompiler::RegexCompiler()
 , states_()
 , state_machine_() 
 {
-    state_machine_.reset( new LexerStateMachine );
-    memset( state_machine_.get(), 0, sizeof(*state_machine_) );
 }
 
 RegexCompiler::~RegexCompiler()
@@ -36,7 +34,7 @@ const LexerStateMachine* RegexCompiler::state_machine() const
     return state_machine_.get();
 }
 
-void RegexCompiler::compile( const std::string& regular_expression, void* symbol, ErrorPolicy* error_policy )
+int RegexCompiler::compile( const std::string& regular_expression, void* symbol, ErrorPolicy* error_policy )
 {
     RegexGenerator generator;
     int errors = generator.generate( regular_expression, symbol, error_policy );
@@ -44,9 +42,10 @@ void RegexCompiler::compile( const std::string& regular_expression, void* symbol
     {
         populate_lexer_state_machine( generator );
     }
+    return errors;
 }
 
-void RegexCompiler::compile( const std::vector<RegexToken>& tokens, ErrorPolicy* error_policy )
+int RegexCompiler::compile( const std::vector<RegexToken>& tokens, ErrorPolicy* error_policy )
 {
     RegexGenerator generator;
     int errors = generator.generate( tokens, error_policy );
@@ -54,6 +53,7 @@ void RegexCompiler::compile( const std::vector<RegexToken>& tokens, ErrorPolicy*
     {
         populate_lexer_state_machine( generator );
     }
+    return errors;
 }
 
 const char* RegexCompiler::add_string( const std::string& string )
@@ -86,6 +86,9 @@ void RegexCompiler::set_states( std::unique_ptr<LexerState[]>& states, int state
 
 void RegexCompiler::populate_lexer_state_machine( const RegexGenerator& generator )
 {
+    state_machine_.reset( new LexerStateMachine );
+    memset( state_machine_.get(), 0, sizeof(*state_machine_) );
+
     const vector<unique_ptr<RegexAction>>& source_actions = generator.actions();
     const set<unique_ptr<RegexState>, RegexStateLess>& source_states = generator.states();
 

--- a/src/lalr/RegexCompiler.hpp
+++ b/src/lalr/RegexCompiler.hpp
@@ -32,8 +32,8 @@ public:
     RegexCompiler();
     ~RegexCompiler();
     const LexerStateMachine* state_machine() const;
-    void compile( const std::string& regular_expression, void* symbol, ErrorPolicy* error_policy = nullptr );
-    void compile( const std::vector<RegexToken>& tokens, ErrorPolicy* error_policy = nullptr );
+    int compile( const std::string& regular_expression, void* symbol, ErrorPolicy* error_policy = nullptr );
+    int compile( const std::vector<RegexToken>& tokens, ErrorPolicy* error_policy = nullptr );
     const char* add_string( const std::string& string );
     void set_actions( std::unique_ptr<LexerAction[]>& actions, int actions_size );
     void set_transitions( std::unique_ptr<LexerTransition[]>& transitions, int transitions_size );

--- a/src/lalr/RegexGenerator.cpp
+++ b/src/lalr/RegexGenerator.cpp
@@ -162,7 +162,7 @@ int RegexGenerator::generate( const std::string& regular_expression, void* symbo
     syntax_tree_->reset( token, this );
     generate_states( *syntax_tree_, &states_, &start_state_ );
     error_policy_ = nullptr;
-    return 0;
+    return syntax_tree_->errors();
 }
 
 int RegexGenerator::generate( const std::vector<RegexToken>& tokens, ErrorPolicy* error_policy )
@@ -176,7 +176,7 @@ int RegexGenerator::generate( const std::vector<RegexToken>& tokens, ErrorPolicy
     syntax_tree_->reset( tokens, this );
     generate_states( *syntax_tree_, &states_, &start_state_ );
     error_policy_ = nullptr;
-    return 0;
+    return syntax_tree_->errors();
 }
 
 /**

--- a/src/lalr/RegexSyntaxTree.hpp
+++ b/src/lalr/RegexSyntaxTree.hpp
@@ -27,7 +27,7 @@ class RegexSyntaxTree
     RegexGenerator* generator_; ///< The RegexGenerator to retrieve actions from and report errors and debug information to.
     std::set<RegexCharacter> bracket_expression_characters_; ///< The characters in the current bracket expression.
     int index_; ///< The current node index.
-    std::vector<std::shared_ptr<RegexNode> > nodes_; ///< The current nodes.
+    std::vector<std::shared_ptr<RegexNode>> nodes_; ///< The current nodes.
     int errors_; ///< The number of errors that have occured.
 
 public:


### PR DESCRIPTION
Terminals appearing in precedence directives but are otherwise undefined need to generate errors otherwise they're assumed to be non-terminals and generate many hard to understand shift/reduce conflicts.

See https://github.com/cwbaker/lalr/issues/11#issuecomment-1459928742.