### PR TITLE
Allow lexer actions for tokens and whitespace to co-exist

### DIFF
--- a/src/lalr/Lexer.hpp
+++ b/src/lalr/Lexer.hpp
@@ -34,6 +34,7 @@ class Lexer
     const void* end_symbol_; ///< The value to return to indicate that the end of the input has been reached.
     ErrorPolicy* error_policy_; ///< The error policy this lexer uses to report errors and debug information.
     std::vector<LexerActionHandler> action_handlers_; ///< The action handlers for this Lexer.
+    std::vector<LexerActionHandler> whitespace_action_handlers_; ///< The action handlers for this Lexer.
     PositionIterator<Iterator> position_; ///< The current position of this Lexer in its input sequence.
     Iterator end_; ///< One past the last position of the input sequence for this Lexer.
     std::basic_string<Char, Traits, Allocator> lexeme_; ///< The most recently matched lexeme.


### PR DESCRIPTION
Previously action handlers for tokens and whitespace were stored in the same vector.  But indices for the tokens and whitespace were overlapped because they are generated for two separate state machines.  Separating them into their own vectors allows the two to work together.