### PR TITLE
Improve whitespace handling

### DIFF
--- a/src/lalr/Grammar.cpp
+++ b/src/lalr/Grammar.cpp
@@ -35,12 +35,14 @@ Grammar::Grammar()
 , active_production_( nullptr )
 , active_symbol_( nullptr )
 , start_symbol_( nullptr )
-, end_symbol_( nullptr ),
-  error_symbol_( nullptr )
+, end_symbol_( nullptr )
+, error_symbol_( nullptr )
+, whitespace_symbol_( nullptr )
 {
     start_symbol_ = add_symbol( ".start", 0, LEXEME_NULL, SYMBOL_NON_TERMINAL );
     end_symbol_ = add_symbol( ".end", 0, LEXEME_NULL, SYMBOL_END );
     error_symbol_ = add_symbol( "error", 0, LEXEME_NULL, SYMBOL_NULL );
+    whitespace_symbol_ = add_symbol( ".whitespace", 0, LEXEME_NULL, SYMBOL_NULL );
 }
 
 Grammar::~Grammar()
@@ -85,6 +87,11 @@ GrammarSymbol* Grammar::end_symbol() const
 GrammarSymbol* Grammar::error_symbol() const
 {
     return error_symbol_;
+}
+
+GrammarSymbol* Grammar::whitespace_symbol() const
+{
+    return whitespace_symbol_;
 }
 
 Grammar& Grammar::grammar( const std::string& identifier )
@@ -265,7 +272,7 @@ Grammar& Grammar::regex( const char* regex, int line )
     LALR_ASSERT( active_whitespace_directive_ || associativity_ != ASSOCIATE_NULL || active_symbol_ );
     if ( active_whitespace_directive_ )
     {
-        whitespace_tokens_.push_back( RegexToken(TOKEN_REGULAR_EXPRESSION, 0, 0, nullptr, regex) );
+        whitespace_tokens_.push_back( RegexToken(TOKEN_REGULAR_EXPRESSION, 0, 0, whitespace_symbol_, regex) );
     }
     else if ( associativity_ != ASSOCIATE_NULL )
     {

--- a/src/lalr/Grammar.hpp
+++ b/src/lalr/Grammar.hpp
@@ -36,6 +36,7 @@ class Grammar
     GrammarSymbol* start_symbol_; ///< The start symbol.
     GrammarSymbol* end_symbol_; ///< The end symbol.
     GrammarSymbol* error_symbol_; ///< The error symbol.
+    GrammarSymbol* whitespace_symbol_; ///< The whitespace symbol.
 
 public:
     Grammar();
@@ -48,6 +49,7 @@ public:
     GrammarSymbol* start_symbol() const;
     GrammarSymbol* end_symbol() const;
     GrammarSymbol* error_symbol() const;
+    GrammarSymbol* whitespace_symbol() const;
     Grammar& grammar( const std::string& identifier );
     Grammar& left( int line );
     Grammar& right( int line );

--- a/src/lalr/GrammarCompiler.cpp
+++ b/src/lalr/GrammarCompiler.cpp
@@ -148,6 +148,7 @@ void GrammarCompiler::set_symbols( std::unique_ptr<ParserSymbol[]>& symbols, int
     parser_state_machine_->start_symbol = &symbols_[0];
     parser_state_machine_->end_symbol = &symbols_[1];
     parser_state_machine_->error_symbol = &symbols_[2];
+    parser_state_machine_->whitespace_symbol = &symbols_[3];
 } 
 
 void GrammarCompiler::set_transitions( std::unique_ptr<ParserTransition[]>& transitions, int transitions_size )

--- a/src/lalr/GrammarGenerator.cpp
+++ b/src/lalr/GrammarGenerator.cpp
@@ -48,6 +48,7 @@ GrammarGenerator::GrammarGenerator()
 , start_symbol_( nullptr )
 , end_symbol_( nullptr )
 , error_symbol_( nullptr )
+, whitespace_symbol_( nullptr )
 , start_state_( nullptr )
 , errors_( 0 )
 {
@@ -88,6 +89,7 @@ int GrammarGenerator::generate( Grammar& grammar, ErrorPolicy* error_policy )
     start_symbol_ = grammar.start_symbol();
     end_symbol_ = grammar.end_symbol();
     error_symbol_ = grammar.error_symbol();
+    whitespace_symbol_ = grammar.whitespace_symbol();
     start_state_ = nullptr;
     errors_ = 0;
 
@@ -381,7 +383,7 @@ void GrammarGenerator::check_for_unreferenced_symbol_errors()
             LALR_ASSERT( symbol );
             
             int references = 0;            
-            if ( symbol != start_symbol_ && symbol != end_symbol_ && symbol->lexeme() != error_symbol_->lexeme() )
+            if ( symbol != start_symbol_ && symbol != end_symbol_ && symbol->lexeme() != error_symbol_->lexeme() && symbol != whitespace_symbol_ )
             {
                 for ( vector<unique_ptr<GrammarProduction>>::const_iterator i = productions_.begin(); i != productions_.end(); ++i )
                 {

--- a/src/lalr/GrammarGenerator.hpp
+++ b/src/lalr/GrammarGenerator.hpp
@@ -38,6 +38,7 @@ class GrammarGenerator
     GrammarSymbol* start_symbol_; ///< The start symbol.
     GrammarSymbol* end_symbol_; ///< The end symbol.
     GrammarSymbol* error_symbol_; ///< The error symbol.
+    GrammarSymbol* whitespace_symbol_; ///< The whitespace symbol.
     GrammarState* start_state_; ///< The start state.
     int errors_; ///< The number of errors that occured during parsing and generation.
 

--- a/src/lalr/ParserStateMachine.hpp
+++ b/src/lalr/ParserStateMachine.hpp
@@ -35,6 +35,7 @@ public:
     const ParserSymbol* start_symbol; ///< The start symbol.
     const ParserSymbol* end_symbol; ///< The end symbol.
     const ParserSymbol* error_symbol; ///< The error symbol.
+    const ParserSymbol* whitespace_symbol; ///< The whitespace symbol.
     const ParserState* start_state; ///< The start state.
     const LexerStateMachine* lexer_state_machine; ///< The state machine used by the lexer to match tokens
     const LexerStateMachine* whitespace_lexer_state_machine; ///< The state machine used by the lexer to skip whitespace

--- a/src/lalr/lalrc/lalrc.cpp
+++ b/src/lalr/lalrc/lalrc.cpp
@@ -356,6 +356,7 @@ void generate_cxx_parser_state_machine( const ParserStateMachine* state_machine 
     write( "    &symbols[%d], // start symbol\n", state_machine->start_symbol->index );
     write( "    &symbols[%d], // end symbol\n", state_machine->end_symbol->index );
     write( "    &symbols[%d], // error symbol\n", state_machine->error_symbol->index );
+    write( "    &symbols[%d], // whitespace symbol\n", state_machine->whitespace_symbol->index );
     write( "    &states[%d], // start state\n", state_machine->start_state->index );
     write( "    %s, // lexer state machine\n", state_machine->lexer_state_machine ? "&lexer_state_machine" : "null" );
     write( "    %s // whitespace lexer state machine\n", state_machine->whitespace_lexer_state_machine ? "&whitespace_lexer_state_machine" : "null" );


### PR DESCRIPTION
Scan for whitespace until no whitespace token matches and reset the position to the start of scanning so that whitespace prefixes that are also valid tokens aren't skipped.