### PR TITLE
Generate state machine from kernel items only

### DIFF
--- a/src/lalr/GrammarGenerator.hpp
+++ b/src/lalr/GrammarGenerator.hpp
@@ -4,6 +4,7 @@
 #include "RegexToken.hpp"
 #include "GrammarSymbolLess.hpp"
 #include "GrammarStateLess.hpp"
+#include "GrammarProductionLess.hpp"
 #include <memory>
 #include <set>
 #include <vector>
@@ -64,12 +65,14 @@ private:
     void check_for_error_symbol_on_left_hand_side_errors();
     void check_for_implicit_terminal_duplicate_associativity();
     void calculate_identifiers();
-    void calculate_terminal_and_non_terminal_symbols();
+    void calculate_terminal_and_non_terminal_symbols();    
     void calculate_implicit_terminal_symbols();
     void calculate_precedence_of_productions();
     void calculate_symbol_indices();
     void calculate_first();
     void calculate_follow();
+    void calculate_reachable_productions();
+    void calculate_reachable_productions_for_symbol( const GrammarSymbol& symbol, std::set<GrammarProduction*, GrammarProductionLess>* productions );
     void generate_states( const GrammarSymbol* start_symbol, const GrammarSymbol* end_symbol, const std::vector<std::unique_ptr<GrammarSymbol>>& symbols );
     void generate_indices_for_states();
     void generate_reduce_transitions();

--- a/src/lalr/GrammarItem.cpp
+++ b/src/lalr/GrammarItem.cpp
@@ -94,7 +94,19 @@ bool GrammarItem::dot_at_end() const
 */
 bool GrammarItem::next_node( const GrammarSymbol& symbol ) const
 {
-    return production_->symbol_by_position(position_) == &symbol;
+    return production_->symbol_by_position( position_ ) == &symbol;
+}
+
+/**
+// Get the symbol after the dot in this item.
+//
+// @return
+//  The next symbol, i.e. following the dot, in this item or null if there
+//  is no such symbol.
+*/
+const GrammarSymbol* GrammarItem::next_symbol() const
+{
+    return production_->symbol_by_position( position_ );
 }
 
 /**

--- a/src/lalr/GrammarItem.hpp
+++ b/src/lalr/GrammarItem.hpp
@@ -29,6 +29,7 @@ public:
     bool dot_at_beginning() const;
     bool dot_at_end() const;
     bool next_node( const GrammarSymbol& symbol ) const;
+    const GrammarSymbol* next_symbol() const;
     const std::set<const GrammarSymbol*, GrammarSymbolLess>& lookahead_symbols() const;
     bool operator<( const GrammarItem& item ) const;
     int add_lookahead_symbols( const std::set<const GrammarSymbol*, GrammarSymbolLess>& lookahead_symbols ) const;

--- a/src/lalr/GrammarProductionLess.cpp
+++ b/src/lalr/GrammarProductionLess.cpp
@@ -1,0 +1,17 @@
+//
+// GrammarProductionLess.cpp
+// Copyright (c) Charles Baker. All rights reserved.
+//
+
+#include "GrammarProductionLess.hpp"
+#include "GrammarProduction.hpp"
+#include "assert.hpp"
+
+using namespace lalr;
+
+bool GrammarProductionLess::operator()( const GrammarProduction* lhs, const GrammarProduction* rhs ) const
+{
+    LALR_ASSERT( lhs->index() >= 0 );
+    LALR_ASSERT( rhs->index() >= 0 );
+    return lhs->index() < rhs->index();
+}

--- a/src/lalr/GrammarProductionLess.hpp
+++ b/src/lalr/GrammarProductionLess.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+namespace lalr
+{
+
+class GrammarProduction;
+
+/**
+// Indirectly compare productions through pointers.
+*/
+class GrammarProductionLess
+{
+public:
+    bool operator()( const GrammarProduction* lhs, const GrammarProduction* rhs ) const;
+};
+
+}

--- a/src/lalr/GrammarState.cpp
+++ b/src/lalr/GrammarState.cpp
@@ -23,6 +23,14 @@ GrammarState::GrammarState()
 {
 }
 
+GrammarState::GrammarState( const GrammarState& state )
+: items_( state.items_ )
+, transitions_( state.transitions_ )
+, processed_( state.processed_ )
+, index_( state.index_ )
+{
+}
+
 /**
 // Get the items in this state.
 //

--- a/src/lalr/GrammarState.hpp
+++ b/src/lalr/GrammarState.hpp
@@ -24,6 +24,7 @@ class GrammarState
 
 public:
     GrammarState();
+    GrammarState( const GrammarState& state );
 
     const std::set<GrammarItem>& items() const;
     const GrammarTransition* find_transition_by_symbol( const GrammarSymbol* symbol ) const;

--- a/src/lalr/GrammarSymbol.cpp
+++ b/src/lalr/GrammarSymbol.cpp
@@ -11,6 +11,7 @@
 using std::set;
 using std::vector;
 using std::shared_ptr;
+using std::make_pair;
 using namespace lalr;
 
 GrammarSymbol::GrammarSymbol( const std::string& lexeme )
@@ -93,6 +94,16 @@ const std::set<const GrammarSymbol*, GrammarSymbolLess>& GrammarSymbol::follow()
 const std::vector<GrammarProduction*>& GrammarSymbol::productions() const
 {
     return productions_;
+}
+
+const std::multimap<const GrammarSymbol*, GrammarProduction*>& GrammarSymbol::reachable_productions_by_first_symbol() const
+{
+    return reachable_productions_by_first_symbol_;
+}
+
+std::multimap<const GrammarSymbol*, GrammarProduction*>::const_iterator GrammarSymbol::find_reachable_productions( const GrammarSymbol& first_symbol ) const
+{
+    return reachable_productions_by_first_symbol_.find( &first_symbol );
 }
 
 /**
@@ -195,6 +206,14 @@ void GrammarSymbol::append_production( GrammarProduction* production )
 {
     LALR_ASSERT( production );
     productions_.push_back( production );
+}
+
+void GrammarSymbol::append_reachable_production( GrammarProduction* production )
+{
+    LALR_ASSERT( production );
+    const GrammarSymbol* first_symbol = production->symbol_by_position( 0 );
+    LALR_ASSERT( first_symbol );
+    reachable_productions_by_first_symbol_.insert( make_pair(first_symbol, production) );
 }
 
 /**

--- a/src/lalr/GrammarSymbol.hpp
+++ b/src/lalr/GrammarSymbol.hpp
@@ -8,6 +8,7 @@
 #include <string>
 #include <vector>
 #include <set>
+#include <map>
 
 namespace lalr
 {
@@ -29,6 +30,7 @@ class GrammarSymbol
     std::set<const GrammarSymbol*, GrammarSymbolLess> first_; ///< The symbols that can start this symbol in a production or regular expression.
     std::set<const GrammarSymbol*, GrammarSymbolLess> follow_; ///< The symbols that can follow this symbol in a production or regular expression.
     std::vector<GrammarProduction*> productions_; ///< The productions that reduce to this symbol.
+    std::multimap<const GrammarSymbol*, GrammarProduction*> reachable_productions_by_first_symbol_; ///< The productions reachable by right-most derivation from this symbol by their first symbol.
 
 public:
     GrammarSymbol( const std::string& lexeme );
@@ -46,6 +48,8 @@ public:
     const std::set<const GrammarSymbol*, GrammarSymbolLess>& first() const;
     const std::set<const GrammarSymbol*, GrammarSymbolLess>& follow() const;
     const std::vector<GrammarProduction*>& productions() const;
+    const std::multimap<const GrammarSymbol*, GrammarProduction*>& reachable_productions_by_first_symbol() const;
+    std::multimap<const GrammarSymbol*, GrammarProduction*>::const_iterator find_reachable_productions( const GrammarSymbol& first_symbol ) const;
     GrammarSymbol* implicit_terminal() const;
     bool matches( const std::string& lexeme, SymbolType symbol_type ) const;
 
@@ -60,6 +64,7 @@ public:
     void set_nullable( bool nullable );
     void set_referenced_in_precedence_directive( bool referenced_in_precedence_directive );
     void append_production( GrammarProduction* production );
+    void append_reachable_production( GrammarProduction* production );
     void calculate_identifier();
     void replace_by_non_terminal( const GrammarSymbol* non_terminal_symbol );    
     int add_symbol_to_first( const GrammarSymbol* symbol );

--- a/src/lalr/lalr.forge
+++ b/src/lalr/lalr.forge
@@ -18,6 +18,7 @@ for _, cc in toolsets('^cc.*') do
                 'GrammarItem.cpp',
                 'GrammarParser.cpp',
                 'GrammarProduction.cpp',
+                'GrammarProductionLess.cpp',
                 'GrammarState.cpp',
                 'GrammarStateLess.cpp',
                 'GrammarSymbol.cpp',


### PR DESCRIPTION
Generate the parser state machine from kernel items only, i.e. those items with a position/dot after the first position.  This change applies that optimization to the initial generation of states only -- the closure of states is still generated to propagate lookaheads through the state machine.  Lookahead propagation will be optimized in a future change.