### PR TITLE
Avoid creating temporary strings adding symbols to Grammar

### DIFF
--- a/src/lalr/GrammarSymbol.cpp
+++ b/src/lalr/GrammarSymbol.cpp
@@ -9,7 +9,7 @@
 
 using namespace lalr;
 
-GrammarSymbol::GrammarSymbol( const std::string& lexeme )
+GrammarSymbol::GrammarSymbol( const char* lexeme )
 : lexeme_( lexeme )
 , identifier_()
 , symbol_type_( SYMBOL_NULL )
@@ -66,8 +66,9 @@ GrammarSymbol* GrammarSymbol::implicit_terminal() const
 }
 
 
-bool GrammarSymbol::matches( const std::string& lexeme, SymbolType symbol_type ) const
+bool GrammarSymbol::matches( const char* lexeme, SymbolType symbol_type ) const
 {
+    LALR_ASSERT( lexeme );
     return lexeme_ == lexeme && symbol_type_ == symbol_type;
 }
 

--- a/src/lalr/GrammarSymbol.hpp
+++ b/src/lalr/GrammarSymbol.hpp
@@ -32,7 +32,7 @@ class GrammarSymbol
     std::multimap<const GrammarSymbol*, GrammarProduction*> reachable_productions_by_first_symbol_; ///< The productions reachable by right-most derivation from this symbol by their first symbol.
 
 public:
-    GrammarSymbol( const std::string& lexeme );
+    GrammarSymbol( const char* lexeme );
 
     inline const std::string& lexeme() const;
     inline const std::string& identifier() const;
@@ -51,7 +51,7 @@ public:
     inline const std::multimap<const GrammarSymbol*, GrammarProduction*>& reachable_productions_by_first_symbol() const;
     std::multimap<const GrammarSymbol*, GrammarProduction*>::const_iterator find_reachable_productions( const GrammarSymbol& first_symbol ) const;
     GrammarSymbol* implicit_terminal() const;
-    bool matches( const std::string& lexeme, SymbolType symbol_type ) const;
+    bool matches( const char* lexeme, SymbolType symbol_type ) const;
 
     void set_lexeme( const std::string& lexeme );
     void set_identifier( const std::string& identifier );


### PR DESCRIPTION
As mentioned by @mingodad in #36 pass lexemes as `const char*` to create and match symbols instead of creating temporary strings and passing them in.  Greatly reduces memory allocations when parsing grammars.